### PR TITLE
Fixing real-time notification by showing existing notification before…

### DIFF
--- a/UI/html/notification.html
+++ b/UI/html/notification.html
@@ -86,7 +86,7 @@
 	<header>
 		<div class="container">
 			<div class="bell">
-				<input id="receiverId"><i id="iconBell" class="fa fa-bell" aria-hidden="true"></i>
+				<input id="receiverId" required><i id="iconBell" class="fa fa-bell" aria-hidden="true"></i>
 			</div>
 			<div class="bel">
 				<i id="iconBel" class="fa fa-bell" aria-hidden="true"></i>
@@ -115,7 +115,7 @@
 			icon.style.display = 'none';
 			iconII.style.display = 'block';
 			panel.style.display = 'block';
-			clientSocket.emit('realReceipt', realReceiverId.value);
+			clientSocket.emit('realReceipt', realReceiverId.value || 0);
 		};
 		icon.addEventListener('click', showNotificationPanel);
 
@@ -124,6 +124,7 @@
 			panel.style.display = 'none';
 			iconII.style.display = 'none';
 			iconIII.style.display = 'block';
+			clientSocket.emit('realReceipt', realReceiverId.value || 0);
 		};
 		iconII.addEventListener('click', hideNotificationPanel);
 
@@ -132,11 +133,24 @@
 			panel.style.display = 'block';
 			iconII.style.display = 'block';
 			iconIII.style.display = 'none';
+			clientSocket.emit('realReceipt', realReceiverId.value || 0);
 		};
 		iconIII.addEventListener('click', showAgainNotificationPanel);
 
 		clientSocket.connect('https://localhost:3000');
 		clientSocket.connect('https://ateam-bn-backend-staging.herokuapp.com');
+
+		clientSocket.on('fechedUserNotification', userData => {
+			const notificationsList = [];
+			var List = document.getElementById("body");
+			for (var i = 0; i < userData.length; i++) {
+				var item = userData[i].description;
+				var elem = document.createElement("li");
+				elem.innerHTML = item;
+				List.appendChild(elem);
+			}
+
+		});
 
 		clientSocket.on('notification', data => {
 			const realTimeNotification = [];
@@ -146,9 +160,10 @@
 				var item = realTimeNotification[i];
 				var elem = document.createElement("li");
 				elem.innerHTML = item;
-				mainList.appendChild(elem);
+				mainList.prepend(elem);
 			}
 		});
+
 
 	</script>
 </body>

--- a/server/controllers/notificationController.js
+++ b/server/controllers/notificationController.js
@@ -2,7 +2,6 @@ import dotenv from 'dotenv';
 import models from '../models';
 
 const { Notification } = models;
-
 dotenv.config();
 /**
  * This class contains all methods
@@ -69,6 +68,16 @@ class Notifications {
       status: 200,
       message: `Notifications marked as ${req.body.viewed}`
     });
+  }
+
+  /**
+     * This method handle the html file.
+     * @param {object} req The user's request.
+     * @param {object} res The user's response.
+     * @returns {object} The status and message.
+     * */
+  static async userNotification(req, res) {
+    return res.sendFile(`/notification.html`, { root: 'UI/html' });
   }
 }
 export default Notifications;

--- a/server/helpers/authHelpers.js
+++ b/server/helpers/authHelpers.js
@@ -174,5 +174,15 @@ class AuthHelpers {
     const userData = await User.findOne({ where: { id: userId } });
     return userData;
   }
+
+  /**
+    * Finds the user's details from user table in database.
+    * @param {integer} argument userId table field.
+    * @returns {object} The user's details.
+    */
+  static async retrieveOneNotificationById(argument) {
+    const userNotification = await Notification.findAll({ where: { receiverId: argument } }).then((userNotify) => userNotify);
+    return userNotification;
+  }
 }
 export default AuthHelpers;

--- a/server/helpers/notifications.js
+++ b/server/helpers/notifications.js
@@ -26,7 +26,7 @@ class Notifications {
       <span style='color: #614e1f;'> Hello, you have new notification for travel which is ${action} for more details
        clieck the link <span style='color: #044F72;'><a href=${url}>${retrievedTrip.tripType}  Request</a> </span> </span><br><br>`;
     const emailNotification = `<span style='color: #7FD8A7 ;'>${status}</span> <br> 
-      <span style='color: #614e1f;'> Hello, you have new notification about a travel which has ${action} </span><br><br>`;
+      <span style='color: #614e1f;'> Hello, You have new notification for travel request which is <span style='color: #7FD8A7 ;'> ${action} </span> </span>`;
     const actions = ['Pending', 'Edited', 'Commented by Requester', 'Rejected', 'Approved', 'Commented by Manager'];
     if (!(actions.includes(action))) {
       return res.status(400).json({

--- a/server/helpers/socket.js
+++ b/server/helpers/socket.js
@@ -1,4 +1,5 @@
 import { io } from '../index';
+import userNotification from './authHelpers';
 
 /* eslint-disable require-jsdoc */
 /**
@@ -10,6 +11,13 @@ class SocketIo {
   socket(receiverId, notification, savedData) {
     const realData = io.sockets.in(receiverId).emit(notification, savedData);
     return realData;
+  }
+
+  async sock(id) {
+    const receiver = await userNotification.retrieveOneNotificationById(id).then((userNotifications) => {
+      io.emit('fechedUserNotification', userNotifications);
+    });
+    return receiver;
   }
 }
 

--- a/server/index.js
+++ b/server/index.js
@@ -3,6 +3,7 @@ import express from 'express';
 import serverSocket from 'socket.io';
 import swaggerUi from 'swagger-ui-express';
 import allRoutes from './routes/allRoutes';
+import userToNotifY from './helpers/socket';
 import apiDocumentation from '../swagger.json';
 import "./middlewares/fbStrategy";
 import "./middlewares/googleStrategy";
@@ -24,7 +25,6 @@ app.get('**', (req, res) => {
     data: `/api/documentation`
   });
 });
-
 const socketListen = app.listen(process.env.PORT, () => {
   console.log('server is running on port 3000');
 });
@@ -33,6 +33,7 @@ io.on('connection', (socket) => {
   console.log('socket Connection is successfully');
   socket.on('realReceipt', (data) => {
     socket.join(data);
+    userToNotifY.sock(data);
   });
 });
 

--- a/server/middlewares/authValidator.js
+++ b/server/middlewares/authValidator.js
@@ -9,7 +9,6 @@ const joiMessageFunction = (error, req, res, next) => {
   }
   return next();
 };
-
 const signUp = (req, res, next) => {
   const schema = Joi.object({
     name: validationObj({ 'string.required': 'name is required', 'string.base': 'Invalid type, your name must be a string', 'string.empty': 'Please enter your name' }),
@@ -21,17 +20,16 @@ const signUp = (req, res, next) => {
     birthdate: Joi.date().iso().required().messages({ 'date.base': 'Birthdate must be a date', 'date.format': 'your birthdate must be in the format YYYY-MM-DD' }),
     preferredLanguage: validationObj({ 'string.base': 'Invalid type, your preferred language must be a string', 'string.empty': 'Please enter your prefeered language' }),
     preferredCurrency: validationObj({ 'string.base': 'Invalid type, your preferred currency must be a string', 'string.empty': 'Please enter your preferred currency' }),
-    location: validationObj({ 'string.base': 'Invalid type, your location must be a string', 'string.empty': 'Please enter your location' }),
+    locationId: Joi.number().integer().required().messages({ 'number.base': 'Invalid type, your location id must be a integer', 'number.empty': 'Please enter your location id' }),
     role: validationObj({ 'string.base': 'Invalid type, your role must be a string', 'string.empty': 'Please enter your role' }),
     department: validationObj({ 'string.base': 'Invalid type, your department must be a string', 'string.empty': 'Please enter your department' }),
-    lineManager: Joi.number().integer().required().messages({ 'integer.base': 'Invalid type, your line manager must be an integer', 'integer.empty': 'Please enter your line manager' })
+    lineManager: Joi.number().integer().required().messages({ 'number.base': 'Invalid type, your line manager\'s id must be a integer', 'number.empty': 'Please enter your line manager\'s id' })
   });
   const { error } = schema.validate(req.body, {
     abortEarly: false
   });
   return joiMessageFunction(error, req, res, next);
 };
-
 const signIn = (req, res, next) => {
   const schema = Joi.object({
     email: validationObj({ 'string.required': 'email is required', 'string.base': 'Invalid type, your email must be a string', 'string.empty': 'Please enter your email' }),
@@ -42,7 +40,6 @@ const signIn = (req, res, next) => {
   });
   return joiMessageFunction(error, req, res, next);
 };
-
 export {
   signUp,
   signIn

--- a/server/routes/notificationRoute.js
+++ b/server/routes/notificationRoute.js
@@ -7,6 +7,7 @@ import check from '../middlewares/notificationFound';
 
 const router = Router();
 
+router.get('/user/notification', notifications.userNotification);
 router.get('/notifications', isTokenValid, notifications.viewNotifications);
 router.post('/notifications/:id/mark', isTokenValid, markNotification, notifications.markOne);
 router.post('/notifications/mark', isTokenValid, check.NotificationFound, markNotification, notifications.markAll);

--- a/swagger.json
+++ b/swagger.json
@@ -558,6 +558,13 @@
         "description": "User can create a trip (One Way Trip, Return Trip and choose Multiple City on a trip)",
         "parameters": [
           {
+            "name": "token",
+            "in": "header",
+            "required": true,
+            "type": "string",
+            "description": "token identify that a user has signed in"
+          },
+          {
             "in": "body",
             "name": "body",
             "description": "data needed to create a trip",
@@ -846,6 +853,226 @@
         }
       }
     },
+    "/accommodation": {
+      "post": {
+        "description": "Travel Admin can create an accommodation",
+        "summary": "Create new Accommodation",
+        "tags": [
+          "Accommodation"
+        ],
+        "operationId": "CreateAccommodation",
+        "deprecated": false,
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "token",
+            "in": "header",
+            "required": true,
+            "type": "string",
+            "description": "security token"
+          },
+          {
+            "in": "formData",
+            "name": "name",
+            "type": "string",
+            "description": "the name of the accommodation"
+          },
+          {
+            "in": "formData",
+            "name": "description",
+            "type": "string",
+            "description": "the description of the accommodation"
+          },
+          {
+            "in": "formData",
+            "name": "image",
+            "type": "file",
+            "description": "upload a picture"
+          },
+          {
+            "in": "formData",
+            "name": "locationId",
+            "type": "string",
+            "description": "the location of the accommodation"
+          },
+          {
+            "in": "formData",
+            "name": "geoLocation",
+            "type": "string",
+            "description": "the geoLocation of the accommodation"
+          },
+          {
+            "in": "formData",
+            "name": "space",
+            "type": "string",
+            "description": "the space available in the accommodation"
+          },
+          {
+            "in": "formData",
+            "name": "cost",
+            "type": "string",
+            "description": "the cost of the accommodation"
+          },
+          {
+            "in": "formData",
+            "name": "highlights",
+            "type": "string",
+            "description": "the highlights that happened"
+          },
+          {
+            "in": "formData",
+            "name": "amenities",
+            "type": "string",
+            "description": "provide the amenities the accommodation provides"
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Accommodation Successfully Supplied",
+            "headers": {}
+          },
+          "400": {
+            "description": "Please select one or more pictures / token is malformed/invalid",
+            "headers": {}
+          },
+          "415": {
+            "description": "Please select the right type of image",
+            "headers": {}
+          },
+          "401": {
+            "description": "You are not allowed to create an accommodation",
+            "headers": {}
+          }
+        }
+      }
+    },
+    "/notifications": {
+      "get": {
+        "description": "User can view all their notifications assigned to them",
+        "summary": "Viewing all Notifications",
+        "tags": [
+          "Notification"
+        ],
+        "operationId": "ViewNotification",
+        "deprecated": false,
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "token",
+            "in": "header",
+            "required": true,
+            "type": "string",
+            "description": "security token"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Lists of all notifications",
+            "content": {},
+            "headers": {}
+          },
+          "404": {
+            "description": "You dont have any notifications",
+            "headers": {}
+          }
+        }
+      }
+    },
+    "/notifications/mark": {
+      "post": {
+        "description": "A user should be able to mark all notifications as read or unread",
+        "summary": " Mark notifications",
+        "tags": [
+          "Notification"
+        ],
+        "operationId": "markNotifications",
+        "deprecated": false,
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "token",
+            "in": "header",
+            "required": true,
+            "type": "string",
+            "description": "security token"
+          },
+          {
+            "name": "Body",
+            "in": "body",
+            "required": true,
+            "description": "User is able to mark all notifications as read or unread",
+            "schema": {
+              "$ref": "#/definitions/markOne"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Notifications marked as read / Notifications marked as unread",
+            "headers": {}
+          },
+          "404": {
+            "description": "Notifications not found",
+            "headers": {}
+          }
+        }
+      }
+    },
+    "/notifications/{id}/mark": {
+      "post": {
+        "description": "A user should be able to mark a notification as read or unread",
+        "summary": " Mark notification",
+        "tags": [
+          "Notification"
+        ],
+        "operationId": "markNotification",
+        "deprecated": false,
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "token",
+            "in": "header",
+            "required": true,
+            "type": "string",
+            "description": "security token"
+          },
+          {
+            "in": "path",
+            "name": "id",
+            "type": "string",
+            "required": true,
+            "description": "parsing a notification id"
+          },
+          {
+            "name": "Body",
+            "in": "body",
+            "required": true,
+            "description": "User is able to mark a notification as read or unread",
+            "schema": {
+              "$ref": "#/definitions/markOne"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Notification marked as read / Notification marked as unread",
+            "headers": {}
+          },
+          "404": {
+            "description": "Notification not found",
+            "headers": {}
+          }
+        }
+      }
+    },
     "/location/most-travelled-destination": {
       "get": {
         "tags": [
@@ -1094,18 +1321,6 @@
         "accommodationId": {
           "type": "integer"
         }
-      },
-      "example": {
-        "tripType": "Return",
-        "from": 1,
-        "to": [
-          2,
-          1
-        ],
-        "date": "2020-02-20",
-        "reasons": "my reason of this trip",
-        "returnDate": "2020-02-23",
-        "accommodationId": 1
       }
     },
     "createComment": {


### PR DESCRIPTION
## WHAT DOES THIS PR DO?

- retrieve existing user notification before real-time notification.

## DESCRIPTION OF TASK TO BE COMPLETED?

- During the completion of this work, I have created a function which will be used to retrieve user notification before receiving new notification.

## HOW SHOULD THIS BE MANUALLY TESTED?

####  The way this will be tested:

- Users should pull from this branch or clone this repository then checkout in this branch with your machine.
- Users after clone this repository should run ```npm install``` command to install all required tools.
- Users after install all required tools should open SQL Shell (psql) and run ```CREATE DATABASE barefoot```.
- Users after creating this Database should run ```npm run test``` script to create a table.
- Users after create and insert data should run ```npm run server``` command to start the server and you should test this by accessing route of request like request trip, modify trip, comment trip in postman. 

## ANY BACKGROUND CONTEXT YOU  WANT TO PROVIDE?

- The context was all about NODEJS with LIBRARIES.
- Some resources:
- [Socket.io Documentation](https://socket.io/).
- [Socket.io Videos Tutorial](https://www.youtube.com/watch?v=vQjiN8Qgs3c).

## WHAT ARE THE RELEVANT PIVOTAL TRACKER STORIES?

- [feature: Send Notification](https://www.pivotaltracker.com/story/show/171102340)

#### Screenshots (if appropriate)

#### When a request runs perfect will get a response in this format below:
####  For application
![receive notification](https://user-images.githubusercontent.com/38179232/74834714-a6c3cf80-5324-11ea-8ef7-93a4a6f12200.PNG)
