### PR TITLE
#171442510 add functionality for assigning users to manager

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -8,7 +8,7 @@ checks:
       threshold: 4
   file-lines:
     config:
-      threshold: 250
+      threshold: 260
   method-complexity:
     config:
       threshold: 25

--- a/UI/html/login-script.js
+++ b/UI/html/login-script.js
@@ -1,6 +1,9 @@
 /* eslint-disable no-undef */
 const socket = io();
 
+const haveToken = localStorage.getItem('token');
+if (haveToken) window.location.href = `${socket.io.uri}/api/barefoot-chat`;
+
 const loginForm = document.getElementById('form');
 const responseContainer = document.querySelector(".response");
 const emailInput = document.querySelector(".emailInput");

--- a/seeders/20200121095153-demo-user.js
+++ b/seeders/20200121095153-demo-user.js
@@ -194,7 +194,59 @@ const jimmyKay = {
   createdAt: new Date(),
   updatedAt: new Date()
 };
-const up = (queryInterface) => queryInterface.bulkInsert('Users', [dummy1, dummy2, dummy3, dummy4, dummy5, dummy6jajaManager, dummy7jajaManager, dummy8jajaRequester, dummy9jajaRequester, manzi, jimmyKay]);
+const Doddy = {
+  name: 'Kalimba K Doddy',
+  gender: 'male',
+  email: 'kwizeradoddy@gmail.com',
+  username: 'doddy',
+  password: Hasher.hashPassword('kalimba123'),
+  birthdate: new Date(),
+  preferredLanguage: 'English',
+  preferredCurrency: 'Euro',
+  locationId: 1,
+  role: 'Super Administrator',
+  department: 'Operations',
+  lineManager: null,
+  isVerified: true,
+  createdAt: new Date(),
+  updatedAt: new Date()
+};
+const Guevara = {
+  name: 'Manzi Guevara',
+  gender: 'male',
+  email: 'manziguevara@gmail.com',
+  username: 'gege',
+  password: Hasher.hashPassword('manzi123'),
+  birthdate: new Date(),
+  preferredLanguage: 'English',
+  preferredCurrency: 'Euro',
+  locationId: 1,
+  role: 'Travel Administrator',
+  department: 'Operations',
+  lineManager: null,
+  isVerified: true,
+  createdAt: new Date(),
+  updatedAt: new Date()
+};
+const Karen = {
+  name: 'Giramata Karen',
+  gender: 'female',
+  email: 'kgiramata57@gmail.com',
+  username: 'karen',
+  password: Hasher.hashPassword('giramata123'),
+  birthdate: new Date(),
+  preferredLanguage: 'English',
+  preferredCurrency: 'Euro',
+  locationId: 1,
+  role: 'Requester',
+  department: 'Operations',
+  lineManager: null,
+  isVerified: true,
+  createdAt: new Date(),
+  updatedAt: new Date()
+};
+
+const up = (queryInterface) => queryInterface.bulkInsert('Users', [dummy1, dummy2, dummy3, dummy4, dummy5, dummy6jajaManager, dummy7jajaManager, dummy8jajaRequester, dummy9jajaRequester, manzi, jimmyKay, Doddy, Guevara, Karen]);
 
 const down = (queryInterface) => queryInterface.bulkDelete('Users', null, {});
 

--- a/server/controllers/userRoleController.js
+++ b/server/controllers/userRoleController.js
@@ -25,4 +25,23 @@ const updateRole = async (req, res) => {
   return res.status(404).json({ status: 404, error: `user with username ${username} does not exist` });
 };
 
-export default updateRole;
+const getAllUsers = async (req, res) => {
+  const allUsers = await AuthHelpers.findAllUsers();
+  res.status(200).json({ status: 200, data: allUsers });
+};
+
+const getAllManagers = async (req, res) => {
+  const allManagers = await AuthHelpers.findAllManagers();
+  res.status(200).json({ status: 200, data: allManagers });
+};
+
+const assignManager = async (req, res) => {
+  const { managerId, requestersIds } = req;
+  const updated = await User.update({ lineManager: managerId }, { where: { id: requestersIds } });
+  if (updated.length) {
+    return res.status(201).json({ status: 201, message: 'operation terminated successfully' });
+  }
+  return res.status(500).json({ status: 500, error: 'error occured while updating lineManager' });
+};
+
+export { updateRole, getAllUsers, getAllManagers, assignManager };

--- a/server/helpers/authHelpers.js
+++ b/server/helpers/authHelpers.js
@@ -184,5 +184,29 @@ class AuthHelpers {
     const userNotification = await Notification.findAll({ where: { receiverId: argument } }).then((userNotify) => userNotify);
     return userNotification;
   }
+
+  /**
+   * Finds all users.
+   * @returns {object} Trip request data.
+   */
+  static async findAllUsers() {
+    const foundUsers = await User.findAll({
+      attributes: ['id', 'name', 'username', 'role', 'lineManager']
+    });
+    return foundUsers;
+  }
+
+  /**
+   * Finds all Managers.
+   * @returns {object} Trip request data.
+   */
+  static async findAllManagers() {
+    const foundUsers = await User.findAll({
+      where: { role: 'Manager' },
+      attributes: ['id', 'name', 'username', 'role', 'lineManager']
+    });
+    return foundUsers;
+  }
 }
+
 export default AuthHelpers;

--- a/server/helpers/socketHelper.js
+++ b/server/helpers/socketHelper.js
@@ -20,4 +20,4 @@ const sockeHelper = (socket) => {
   });
 };
 
-export default { sockeHelper };
+export default sockeHelper;

--- a/server/middlewares/assignManagerValidator.js
+++ b/server/middlewares/assignManagerValidator.js
@@ -1,0 +1,81 @@
+import Joi from '@hapi/joi';
+import models from '../models';
+
+const { User } = models;
+
+/**
+ * This class contains all methods
+ * required to handle
+ * trip endpoints' request.
+ */
+class validateManagerAssignment {
+  /**
+   * This method validates ids passed to the route.
+   * @param {object} req The user's request.
+   * @param {object} res The response.
+   * @param {object} next The the next line.
+   * @returns {object} The status and some data of the trip.
+   */
+  static async validateIds(req, res, next) {
+    const { manager, requesters } = req.body;
+    const missingRequesters = [];
+    let errorMessage;
+
+    const managerExists = await User.findOne({
+      attributes: ['id', 'name', 'username', 'role', 'lineManager'],
+      where: { id: manager, role: 'Manager' }
+    });
+    const requestersExist = await User.findAll({
+      attributes: ['id', 'name', 'username', 'role', 'lineManager'],
+      where: { id: requesters, role: 'Requester' }
+    });
+
+    if (!managerExists) {
+      errorMessage = `no manager was found with id matching ${manager}`;
+    }
+    if (requestersExist.length !== requesters.length) {
+      requesters.forEach((id) => {
+        if (!requestersExist.find((user) => user.id === id)) {
+          missingRequesters[missingRequesters.length] = id;
+        }
+      });
+      if (errorMessage) {
+        errorMessage += `, and requesters with id matching ${missingRequesters} were not found`;
+      } else {
+        errorMessage = `requesters with id matching ${missingRequesters} were not found`;
+      }
+    }
+
+    if (!errorMessage) {
+      req.managerId = manager;
+      req.requestersIds = requesters;
+      return next();
+    }
+    return res.status(400).json({ status: 400, error: errorMessage });
+  }
+
+  /**
+   * This method validates ids passed to the route.
+   * @param {object} req The user's request.
+   * @param {object} res The response.
+   * @param {object} next The the next line.
+   * @returns {object} The status and some data of the trip.
+   */
+  static async validateFields(req, res, next) {
+    const schema = Joi.object({
+      manager: Joi.number().integer().required().messages({ 'number.base': 'Invalid type, managerId must be an integer', 'number.unsafe': 'only manager id of type integer are allowed' }),
+      requesters: Joi.array().items(Joi.number().integer()).required().messages({ 'number.unsafe': 'only requester id numbers of type integer are allowed' })
+    });
+    const { error } = schema.validate(req.body, {
+      abortEarly: false
+    });
+    if (error) {
+      const { details } = error;
+      const message = details.map((i) => i.message.replace(/"/g, '')).join(', ');
+      return res.status(400).json({ status: 400, error: message });
+    }
+    return next();
+  }
+}
+
+export default validateManagerAssignment;

--- a/server/middlewares/isRequester.js
+++ b/server/middlewares/isRequester.js
@@ -1,0 +1,8 @@
+const checkRequester = (req, res, next) => {
+  if (req.user.role !== 'Requester') {
+    return res.status(401).json({ status: 401, error: 'only requesters are allowed to access this service' });
+  }
+  return next();
+};
+
+export default checkRequester;

--- a/server/middlewares/roleValidator.js
+++ b/server/middlewares/roleValidator.js
@@ -3,7 +3,7 @@ import Joi from '@hapi/joi';
 const validate = (req, res, next) => {
   const Schema = Joi.object().keys({
     role: Joi.string().trim()
-      .required().pattern(new RegExp('^Super Administrator$|^Travel Administrator$|^Travel Team Member$|^Manager$|^Requester$', 'i'))
+      .required().pattern(new RegExp('^Super Administrator$|^Travel Administrator$|^Manager$|^Requester$', 'i'))
   });
   const result = Schema.validate({ role: req.body.role }, {
     abortEarly: false
@@ -12,7 +12,7 @@ const validate = (req, res, next) => {
   if (valid) {
     return next();
   }
-  return res.status(400).json({ status: 400, error: 'anly the follwing values are allowed: Super Administrator, Travel Administrator, Travel Team Member, Manager,Requester' });
+  return res.status(400).json({ status: 400, error: 'anly the follwing values are allowed: Super Administrator, Travel Administrator, Manager,Requester' });
 };
 
 export default validate;

--- a/server/routes/tripRoutes.js
+++ b/server/routes/tripRoutes.js
@@ -6,11 +6,12 @@ import { tripValidator, tripChecker } from '../middlewares/tripValidation';
 import tokenValidator from "../middlewares/tokenValidator";
 import { checkTripId, isOwned, isEditable } from '../middlewares/tripExists';
 import checkRememberFields from '../middlewares/checkRememberFields';
+import checkRequester from '../middlewares/isRequester';
 
 const router = Router();
 
 router.post(
-  '/trips', tokenValidator, rememberMeValidation.IfRememberProfile, tripValidator('trip', 'body'), tripChecker,
+  '/trips', tokenValidator, checkRequester, rememberMeValidation.IfRememberProfile, tripValidator('trip', 'body'), tripChecker,
   asyncErrorHandler(TripController.oneWayTrip)
 );
 

--- a/server/routes/userRoleRoutes.js
+++ b/server/routes/userRoleRoutes.js
@@ -1,11 +1,15 @@
 import Router from 'express';
 import validateToken from '../middlewares/tokenValidator';
 import isSuperAdmin from '../middlewares/isSuperAdmin';
-import userRoleController from '../controllers/userRoleController';
+import { updateRole, getAllUsers, getAllManagers, assignManager } from '../controllers/userRoleController';
 import validateRole from '../middlewares/roleValidator';
+import validationClass from '../middlewares/assignManagerValidator';
 
 const router = Router();
 
-router.patch('/users/:username/role', validateToken, isSuperAdmin, validateRole, userRoleController);
+router.patch('/users/:username/role', validateToken, isSuperAdmin, validateRole, updateRole);
+router.get('/users', validateToken, isSuperAdmin, getAllUsers);
+router.get('/users/managers', validateToken, isSuperAdmin, getAllManagers);
+router.put('/users/managers/assign', validateToken, isSuperAdmin, validationClass.validateFields, validationClass.validateIds, assignManager);
 
 export default router;

--- a/server/tests/managerAssignment.test.js
+++ b/server/tests/managerAssignment.test.js
@@ -1,0 +1,91 @@
+import chai from 'chai';
+import http from 'chai-http';
+import index from '../index';
+
+chai.use(http);
+chai.should();
+
+let superAdminToken;
+
+const validAssignment = {
+  requesters: [8, 9, 10, 11],
+  manager: 3
+};
+const invalidAssignment = {
+  requesters: [8, 9, 4, 11],
+  manager: 8
+};
+const invalidAssignmentManager = {
+  requesters: [8, 9, "10adsfasdf", 11],
+  manager: 3
+};
+const invalidAssignmentRequester = {
+  requesters: [3, 9, 10, 11],
+  manager: 3
+};
+
+describe('running user role update route tests', () => {
+  it('Super administrator login request', async () => {
+    const result = await chai
+      .request(index)
+      .post('/api/auth/signin')
+      .send({ email: 'kwizeradoddy@gmail.com', password: 'kalimba123' });
+    superAdminToken = result.body.data.token;
+    result.should.have.status(200);
+    result.body.should.be.an('object');
+  });
+  it('a super administrator should be able to assign a requesters to a manager', async () => {
+    const result = await chai
+      .request(index)
+      .put('/api/users/managers/assign')
+      .send(validAssignment)
+      .set('token', superAdminToken);
+    result.should.have.status(201);
+    result.body.should.have.property('message', 'operation terminated successfully');
+  });
+  it('a super administrator should be able to view all managers', async () => {
+    const result = await chai
+      .request(index)
+      .get('/api/users/managers')
+      .send()
+      .set('token', superAdminToken);
+    result.should.have.status(200);
+    result.body.should.have.property('data');
+  });
+  it('a super administrator should be able to view all users', async () => {
+    const result = await chai
+      .request(index)
+      .get('/api/users')
+      .send()
+      .set('token', superAdminToken);
+    result.should.have.status(200);
+    result.body.should.have.property('data');
+  });
+  it('a super administrator should not be able to assign a requesters to a manager when managersId is not valid', async () => {
+    const result = await chai
+      .request(index)
+      .put('/api/users/managers/assign')
+      .send(invalidAssignment)
+      .set('token', superAdminToken);
+    result.should.have.status(400);
+    result.body.should.have.property('error');
+  });
+  it('a super administrator should not be able to assign a requesters to a manager if requesterIds are not valid', async () => {
+    const result = await chai
+      .request(index)
+      .put('/api/users/managers/assign')
+      .send(invalidAssignmentManager)
+      .set('token', superAdminToken);
+    result.should.have.status(400);
+    result.body.should.have.property('error');
+  });
+  it('a super administrator should be able to assign a requesters to a manager only when all requester Ids are valid', async () => {
+    const result = await chai
+      .request(index)
+      .put('/api/users/managers/assign')
+      .send(invalidAssignmentRequester)
+      .set('token', superAdminToken);
+    result.should.have.status(400);
+    result.body.should.have.property('error');
+  });
+});

--- a/server/tests/trip.test.js
+++ b/server/tests/trip.test.js
@@ -245,7 +245,7 @@ describe('remembered profile tests', () => {
     const res = await chai
       .request(app)
       .post('/api/auth/signin')
-      .send({ email: 'nigorjeanluc@gmail.com', password: 'secret123' });
+      .send({ email: 'JkayOne2@gmail.com', password: '123456789' });
     tokenFalse = res.body.data.token;
     res.should.have.status(200);
     res.body.should.be.an('object');
@@ -277,6 +277,26 @@ describe('Test for create one way trip endpoint', () => {
   let rememberToken;
   let unauthorizedToken;
   let managerToken;
+  let superToken;
+
+  it('user should first login', async () => {
+    const result = await chai.request(app)
+      .post('/api/auth/signin')
+      .send({ email: 'kwizeradoddy@gmail.com', password: 'kalimba123' });
+    superToken = result.body.data.token;
+    result.should.have.status(200);
+    result.body.should.be.an('object');
+  });
+
+  it('a signed in super admin should be able to update a particular user role ', async () => {
+    const result = await chai
+      .request(app)
+      .patch('/api/users/MrDummy2/role')
+      .send({ role: 'Requester' })
+      .set('token', superToken);
+    result.should.have.status(201);
+    result.body.should.have.property('message', 'user role updated successfully');
+  });
 
   it('user should first login', async () => {
     const result = await chai.request(app)
@@ -419,6 +439,58 @@ describe('Test for create one way trip endpoint', () => {
       .set('token', tokenTrue);
     result.should.have.status(401);
     result.body.should.have.property('error');
+  });
+  it('a signed in super admin should be able to update a particular user role ', async () => {
+    const result = await chai
+      .request(app)
+      .patch('/api/users/MrDummy2/role')
+      .send({ role: 'Super Administrator' })
+      .set('token', superToken);
+    result.should.have.status(201);
+    result.body.should.have.property('message', 'user role updated successfully');
+  });
+});
+
+describe('viewing all trips test', () => {
+  let viewToken;
+  let managerToken;
+
+  it('logging in a requester', async () => {
+    const res = await chai
+      .request(app)
+      .post('/api/auth/signin')
+      .send({ email: 'dummy8jaja@email.rw', password: '123456789' });
+    viewToken = res.body.data.token;
+    res.should.have.status(200);
+    res.body.should.be.an('object');
+  });
+
+  it('logging in a manager', async () => {
+    const res = await chai
+      .request(app)
+      .post('/api/auth/signin')
+      .send({ email: 'nigorjeanluc@gmail.com', password: 'secret123' });
+    managerToken = res.body.data.token;
+    res.should.have.status(200);
+    res.body.should.be.an('object');
+  });
+
+  it('a requester user should only view their own trip requests', async () => {
+    const result = await chai.request(app)
+      .get('/api/trips')
+      .send()
+      .set('token', viewToken);
+    result.should.have.status(200);
+    result.body.should.have.property('data');
+  });
+
+  it('a manager user should view all trip requests', async () => {
+    const result = await chai.request(app)
+      .get('/api/trips')
+      .send()
+      .set('token', managerToken);
+    result.should.have.status(200);
+    result.body.should.have.property('data');
   });
 });
 

--- a/swagger.json
+++ b/swagger.json
@@ -1560,6 +1560,105 @@
           }
         }
       }
+    },
+    "/users": {
+      "get": {
+        "tags": [
+          "View Users"
+        ],
+        "summary": "Viewing all users",
+        "description": "a Super administrator user views all users",
+        "parameters": [
+          {
+            "name": "token",
+            "in": "header",
+            "required": true,
+            "type": "string",
+            "description": "token to identify a signed in and authentic super administrator"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "users successfuly retrieved"
+          },
+          "400": {
+            "description": "Malformed/ Incorrect security token ! Check token and try again."
+          },
+          "401": {
+            "description": "User not recognised. Please create account and try again./ Already logged out. Sign in and try again."
+          }
+        }
+      }
+    },
+    "/users/managers": {
+      "get": {
+        "tags": [
+          "View Users"
+        ],
+        "summary": "Viewing all Managers",
+        "description": "a Super administrator user views all users with Manager privileges",
+        "parameters": [
+          {
+            "name": "token",
+            "in": "header",
+            "required": true,
+            "type": "string",
+            "description": "token to identify a signed in and authentic super administrator"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Managers successfuly retrieved"
+          },
+          "400": {
+            "description": "Malformed/ Incorrect security token ! Check token and try again."
+          },
+          "401": {
+            "description": "User not recognised. Please create account and try again./ Already logged out. Sign in and try again."
+          }
+        }
+      }
+    },
+    "/users/managers/assign": {
+      "put": {
+        "tags": [
+          "Manager Assignment"
+        ],
+        "summary": "Assign Requesters to Managers",
+        "description": "a super administrator can assign users to to a particular manager",
+        "parameters": [
+          {
+            "name": "token",
+            "in": "header",
+            "required": true,
+            "type": "string",
+            "description": "token to identify a signed in and authentic super administrator"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "data needed to create a trip",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ManagerAssignment"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Requesters assigned successfully"
+          },
+          "400": {
+            "description": "Malformed/ Incorrect security token ! Check token and try again. or invalid fields"
+          },
+          "401": {
+            "description": "User not recognised. Please create account and try again./ Already logged out. Sign in and try again / not an authorized super admin"
+          },
+          "500": {
+            "description": "database error while assigning requesters to manager"
+          }
+        }
+      }
     }
   },
   "definitions": {
@@ -1920,6 +2019,26 @@
           "type": "date"
         }
       }
+    },
+    "ManagerAssignment": {
+      "title": "Assign requesters to managers",
+      "example": {
+        "requesters": [8,9,10,11],
+        "manager": 3
+      },
+      "type": "object",
+      "properties": {
+        "requesters": {
+          "type": "array"
+        },
+        "birthdate": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "requesters",
+        "manager"
+      ]
     }
   }
 }


### PR DESCRIPTION
### What does this PR do
It adds an endpoint that allows <strong>Super Administrators</strong> to to assign Requester users to their Managers
### Description of the tasks to be completed
- add a route for getting all users, that is only accessible to users with super administrator privileges.
- add a route for getting all manager users, that is only accessible to users with super administrator privileges.
- add route that will be used to assign Requester users to their managers
- validate <strong><em>manager</em></strong> and <strong><em>requesters</em></strong> fields so that only valid user_IDs are passed in.
- create a middle_ware that will only allow users with Requester privileges to book trip requests.
- remove <strong><em>Travel Team Member</em></strong> role from accepted roles
- test all newly created functions & routes.
- document the three routes with swagger.

### How should this be manually tested
Clone the repository and follow the swagger api documentation.
### What are the relevant pivotal tracker stories
[#171442510](https://www.pivotaltracker.com/story/show/171442510)
