### PR TITLE
Fixed profile routes

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -17,6 +17,9 @@
     "consistent-return": 0,
     "no-param-reassign": 0,
     "class-methods-use-this": 0,
+    "function-paren-newline": 0,
+    "object-curly-newline": 0,
+    "prefer-destructuring": 0,
     "comma-dangle": 0,
     "linebreak-style": 0,
     "arrow-parens": [

--- a/server/controllers/profileController.js
+++ b/server/controllers/profileController.js
@@ -10,7 +10,7 @@ dotenv.config();
 const viewProfile = async (req, res) => {
   const foundUser = await User.findOne({
     where: {
-      username: req.params.username
+      id: req.user.id
     }
   });
   res.status(200).json({

--- a/server/routes/userProfile.js
+++ b/server/routes/userProfile.js
@@ -1,6 +1,5 @@
 import { Router } from 'express';
 import multiparty from 'connect-multiparty';
-import isProfileOwner from '../middlewares/isProfileOwner';
 import validateProfile from '../middlewares/profileValidator';
 import validateProfileImage from '../middlewares/ProfileImageValidator';
 import validateCoverImage from '../middlewares/coverImageValidator';
@@ -17,11 +16,10 @@ import validateReaction from '../middlewares/reactionvalidation';
 const router = Router();
 const multipart = multiparty();
 
-router.get('/profile/:username', isTokenValid, isProfileOwner, viewProfile);
+router.get('/profile', isTokenValid, viewProfile);
 router.patch(
-  '/profile/:username',
+  '/profile',
   isTokenValid,
-  isProfileOwner,
   multipart,
   validateProfile,
   validateProfileImage,

--- a/server/tests/profileRoute.test.js
+++ b/server/tests/profileRoute.test.js
@@ -45,27 +45,17 @@ describe('running profile route tests', () => {
   it('user should be able to view details of his/her profile', async () => {
     const result = await chai
       .request(index)
-      .get('/api/profile/kay')
+      .get('/api/profile')
       .send()
       .set('token', jimmyToken);
     result.should.have.status(200);
     result.body.should.have.property('data');
   });
 
-  it('user should not be allowed to view a not owned profile', async () => {
-    const result = await chai
-      .request(index)
-      .get('/api/profile/manzi')
-      .send()
-      .set('token', jimmyToken);
-    result.should.have.status(401);
-    result.body.should.have.property('error', 'unauthorized, profile not owned or token bears wrong data');
-  });
-
   it('user should be not be allowed to view a profile with an incorrect token', async () => {
     const result = await chai
       .request(index)
-      .get('/api/profile/kay')
+      .get('/api/profile')
       .send()
       .set('token', wrongToken);
     result.should.have.status(400);
@@ -75,7 +65,7 @@ describe('running profile route tests', () => {
   it('user should be not be allowed to view a profile when not registered', async () => {
     const result = await chai
       .request(index)
-      .get('/api/profile/kay')
+      .get('/api/profile')
       .send()
       .set('token', karenToken);
     result.should.have.status(401);
@@ -85,7 +75,7 @@ describe('running profile route tests', () => {
   it('user should be able to update his/her profile', async () => {
     const result = await chai
       .request(index)
-      .patch('/api/profile/kay')
+      .patch('/api/profile')
       .send(updatedJimmy)
       .set('token', jimmyToken);
     result.should.have.status(201);
@@ -95,7 +85,7 @@ describe('running profile route tests', () => {
   it('user should be able to update his/her profile with a profile photo and cover photo', async () => {
     const result = await chai
       .request(index)
-      .patch('/api/profile/kay')
+      .patch('/api/profile')
       .field('name', updatedJimmy.name)
       .field('birthdate', updatedJimmy.birthdate)
       .field('gender', updatedJimmy.gender)
@@ -112,7 +102,7 @@ describe('running profile route tests', () => {
   it('user should be able to update his/her profile with a profile photo and cover photo', async () => {
     const result = await chai
       .request(index)
-      .patch('/api/profile/kay')
+      .patch('/api/profile')
       .field('name', updatedJimmy.name)
       .field('birthdate', updatedJimmy.birthdate)
       .field('gender', updatedJimmy.gender)
@@ -128,7 +118,7 @@ describe('running profile route tests', () => {
   it('user should be able to update his/her profile with a profile photo and cover photo', async () => {
     const result = await chai
       .request(index)
-      .patch('/api/profile/kay')
+      .patch('/api/profile')
       .field('name', updatedJimmy.name)
       .field('birthdate', updatedJimmy.birthdate)
       .field('gender', updatedJimmy.gender)
@@ -144,7 +134,7 @@ describe('running profile route tests', () => {
   it('user should not be able to update his/her profile with an invalid profile photo and/or cover photo', async () => {
     const result = await chai
       .request(index)
-      .patch('/api/profile/kay')
+      .patch('/api/profile')
       .field('name', updatedJimmy.name)
       .field('birthdate', updatedJimmy.birthdate)
       .field('gender', updatedJimmy.gender)
@@ -161,7 +151,7 @@ describe('running profile route tests', () => {
   it('user should not be able to update his/her profile with an invalid profile photo and/or cover photo (wrong extension)', async () => {
     const result = await chai
       .request(index)
-      .patch('/api/profile/kay')
+      .patch('/api/profile')
       .field('name', updatedJimmy.name)
       .field('birthdate', updatedJimmy.birthdate)
       .field('gender', updatedJimmy.gender)
@@ -178,7 +168,7 @@ describe('running profile route tests', () => {
   it('user should not be able to update his/her profile with more than one profile and/or cover photos', async () => {
     const result = await chai
       .request(index)
-      .patch('/api/profile/kay')
+      .patch('/api/profile')
       .field('name', updatedJimmy.name)
       .field('birthdate', updatedJimmy.birthdate)
       .field('gender', updatedJimmy.gender)
@@ -197,7 +187,7 @@ describe('running profile route tests', () => {
   it('user should not be able to update his/her profile with invalid fields', async () => {
     const result = await chai
       .request(index)
-      .patch('/api/profile/kay')
+      .patch('/api/profile')
       .send(updatedInvalidJimmy)
       .set('token', jimmyToken);
     result.should.have.status(400);


### PR DESCRIPTION
## WHAT DOES THIS PR DO?

- I correct user profile routes


## DESCRIPTION OF TASK TO BE COMPLETED?

- During the completion of this work, now we can access a user profile by using token information only.

## HOW SHOULD THIS BE MANUALLY TESTED?

####  The way this will be tested:
- Users should pull from this branch with this command ``` git pull origin Fix-profile-routes ```
- Also, users should clone this repository into a machine with this command ``` git clone https://github.com/Stackup-Rwanda/ateam-bn-backend.git ```
- Then users should run this command ``` cd ateam-bn-backend```
- Then User should run this command in your terminal ``` git checkout Fix-profile-routes``` 
- Users after should run ```npm install``` command to install all required tools.
- Users will have to run ```npm run server``` command to start an application.
- Users should use this route to test the functionalities ```localhost:4000/api/profile/``` for local and ```https://ateam-bn-backend-staging.herokuapp.com/api/profile/``` for Heroku app

## ANY BACKGROUND CONTEXT YOU  WANT TO PROVIDE?

- The context is all about Nodejs.

## Screenshots (if appropriate)
#### Before Changes
![before](https://user-images.githubusercontent.com/38179232/77851639-7cdeb200-71da-11ea-93d0-d1619fc6e431.PNG)

#### After Changes
![after](https://user-images.githubusercontent.com/38179232/77851722-e2cb3980-71da-11ea-9f15-ebcfdd7a5dd1.PNG)



