### PR TITLE
change logout route method to post

### DIFF
--- a/server/routes/authRoutes.js
+++ b/server/routes/authRoutes.js
@@ -24,7 +24,7 @@ router
   .patch('/auth/update-password/:userId/:token', Validations.checkPassword, Validations.checkPasswordAnConfirmPassword, userIdExistMiddleware, resetEmailTokenMiddleware, asyncErrorHandler(EmailController.updatePassword))
   .get('/user/:email/confirm', AuthController.confirmation)
   .post('/auth/signin', signIn, asyncErrorHandler(AuthController.signIn))
-  .get('/auth/logout', importedTokenValidator, AuthController.logout)
+  .post('/auth/logout', importedTokenValidator, AuthController.logout)
   .get('/auth/google', passport.authenticate('google', { scope: ['profile', 'email'] }))
   .get('/auth/google/callback', passport.authenticate('google', { session: false }), asyncErrorHandler(OAuthController.storeAuth))
   .get('/auth/facebook', passport.authenticate('facebook', { scope: ['email'] }))

--- a/server/tests/logout.test.js
+++ b/server/tests/logout.test.js
@@ -19,7 +19,7 @@ describe('my Testing suite', () => {
   });
   it('users should be able to logout from application', (done) => {
     router()
-      .get('/api/auth/logout')
+      .post('/api/auth/logout')
       .set('token', validtoken)
       .end((error, response) => {
         expect(response).to.have.status([200]);
@@ -34,7 +34,7 @@ describe('my Testing suite', () => {
 
   it('users should not click twice on button of logout from application', (done) => {
     router()
-      .get('/api/auth/logout')
+      .post('/api/auth/logout')
       .set('token', validtoken)
       .end((error, response) => {
         expect(response).to.have.status([401]);
@@ -48,7 +48,7 @@ describe('my Testing suite', () => {
   });
   it('users should not logout when does not exist in database', (done) => {
     router()
-      .get('/api/auth/logout')
+      .post('/api/auth/logout')
       .set('token', Unexistuser)
       .end((error, response) => {
         expect(response).to.have.status([401]);


### PR DESCRIPTION
### What does this PR do?
It changes the logout route to a post method instead of get
### Description of the task to be completed
- in **authRoutes** change 'get' method on /auth/logout to 'post'
- modify the test to use post instead of get
### How should this be manually tested
pull the branch, install packages and run the server
then signin a user and use the logout route with a post method
### What are the relevant pivotal tracker stories
N/A