### PR TITLE
Fetch only requests of manager's assigned requesters

### DIFF
--- a/server/helpers/searchHelper.js
+++ b/server/helpers/searchHelper.js
@@ -29,7 +29,7 @@ class SearchHelpers {
       },
       include: [{
         model: User,
-        as: "Users",
+        as: "User",
         attributes: ['name', 'email', 'username', 'role', 'locationId', 'lineManager', 'gender', 'createdAt', 'updatedAt']
       }]
 
@@ -52,7 +52,7 @@ class SearchHelpers {
       },
       include: [{
         model: User,
-        as: "Users",
+        as: "User",
         attributes: ['name', 'email', 'username', 'role', 'locationId', 'lineManager', 'gender', 'createdAt', 'updatedAt']
       }]
     });
@@ -74,7 +74,7 @@ class SearchHelpers {
       },
       include: [{
         model: User,
-        as: "Users",
+        as: "User",
         attributes: ['name', 'email', 'username', 'role', 'locationId', 'lineManager', 'gender', 'createdAt', 'updatedAt'],
 
       }],
@@ -100,7 +100,7 @@ class SearchHelpers {
       },
       include: [{
         model: User,
-        as: "Users",
+        as: "User",
         attributes: ['name', 'email', 'username', 'role', 'locationId', 'lineManager', 'gender', 'createdAt', 'updatedAt']
       }]
 
@@ -125,7 +125,7 @@ class SearchHelpers {
         },
         include: [{
           model: User,
-          as: "Users",
+          as: "User",
           attributes: ['name', 'email', 'username', 'role', 'locationId', 'lineManager', 'gender', 'createdAt', 'updatedAt']
         }]
 
@@ -154,7 +154,7 @@ class SearchHelpers {
         },
         include: [{
           model: User,
-          as: "Users",
+          as: "User",
           attributes: ['name', 'email', 'username', 'role', 'locationId', 'lineManager', 'gender', 'createdAt', 'updatedAt']
         }]
 

--- a/server/helpers/tripHelpers.js
+++ b/server/helpers/tripHelpers.js
@@ -22,7 +22,7 @@ class TripHelpers {
       include: [
         {
           model: User,
-          as: 'Users',
+          as: 'User',
           attributes: ['id', 'role', 'lineManager']
         }
       ]
@@ -69,7 +69,16 @@ class TripHelpers {
   static async findTripByRole(role, id, skip, start) {
     let foundTrip;
     if (role === 'MANAGER') {
-      foundTrip = await Trip.findAndCountAll({ limit: skip,
+      const assignedUsers = await User.findAndCountAll({
+        where: { lineManager: id },
+        attributes: ['id', 'name', 'email', 'username', 'role', 'lineManager']
+      });
+
+      const users = assignedUsers.rows.map((user) => user.id);
+
+      foundTrip = await Trip.findAndCountAll({
+        where: { userId: users },
+        limit: skip,
         offset: start,
         order: [['id', 'DESC']],
         include:
@@ -78,6 +87,19 @@ class TripHelpers {
             model: Accommodations,
             as: 'Accommodations',
             attributes: ['id', 'image', 'name']
+          },
+          {
+            model: User,
+            as: 'User',
+            attributes: [
+              'id',
+              'name',
+              'email',
+              'profilePhoto',
+              'coverPhoto',
+              'department',
+              'username'
+            ]
           }
         ]
       });

--- a/server/middlewares/tripExists.js
+++ b/server/middlewares/tripExists.js
@@ -1,10 +1,17 @@
 import models from '../models';
 
-const { Trip } = models;
+const { Trip, User } = models;
 
 const tripFound = async (id, req) => {
   const exists = await Trip.findOne({
-    where: { id }
+    where: { id },
+    include: [
+      {
+        model: User,
+        as: 'User',
+        attributes: ['id', 'role', 'lineManager']
+      }
+    ]
   });
   if (exists) {
     req.oldTrip = exists;

--- a/server/models/trip.js
+++ b/server/models/trip.js
@@ -54,7 +54,7 @@ const tripDefinition = (sequelize, DataTypes) => {
   Trip.associate = (models) => {
     Trip.belongsTo(models.User, {
       foreignKey: 'userId',
-      as: 'Users',
+      as: 'User',
       onDelete: 'CASCADE'
     });
     Trip.belongsTo(models.Accommodations, {

--- a/server/tests/managerAssignment.test.js
+++ b/server/tests/managerAssignment.test.js
@@ -40,6 +40,7 @@ describe('running user role update route tests', () => {
       .put('/api/users/managers/assign')
       .send(validAssignment)
       .set('token', superAdminToken);
+    console.log(result.body);
     result.should.have.status(201);
     result.body.should.have.property('message', 'operation terminated successfully');
   });
@@ -49,6 +50,7 @@ describe('running user role update route tests', () => {
       .get('/api/users/managers')
       .send()
       .set('token', superAdminToken);
+    console.log(result.body);
     result.should.have.status(200);
     result.body.should.have.property('data');
   });


### PR DESCRIPTION
#### What does this PR do?
This pull request ensures that a Manager can view all trip requests done by his/her assigned requesters
### Description of Task to be completed?
 - add a method to fetch all assigned requesters and fetch their trip requests in the file `server/helpers/tripHelpers.js`.
#### How should this be manually tested?
You can pull the `develop` or `retrieve-requests-for-manager` branch and run these following commands `npm install` and run `npm test` 
#### What are the relevant pivotal tracker stories?
N/A